### PR TITLE
Using par-dual to validate refinement types HTTP requests

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,5 +1,21 @@
 let
-  pkgs = import (fetchTarball "https://github.com/NixOS/nixpkgs-channels/archive/10100a97c89.tar.gz") {};
+  # Override to use the `par-dual-1.0.0.0` package
+  config = {
+    packageOverrides = pkgs: rec {
+      haskellPackages = pkgs.haskellPackages.override {
+        overrides = haskellPackagesNew: haskellPackagesOld: rec {
+          par-dual =
+            haskellPackagesNew.callCabal2nix "par-dual" (builtins.fetchGit {
+              url = "https://github.com/gvolpe/par-dual.git";
+              rev = "49ad0c2102e061d38133540a2d6dcf75d4dac69c";
+            }) {};
+          };
+        };
+      };
+    };
+
+  pkgs = import (fetchTarball "https://github.com/NixOS/nixpkgs-channels/archive/10100a97c89.tar.gz") { inherit config; };
+
   inherit (pkgs) haskellPackages;
   drv = haskellPackages.callCabal2nix "shopping-cart" ./. {};
 

--- a/shopping-cart.cabal
+++ b/shopping-cart.cabal
@@ -53,6 +53,7 @@ library
                      , exceptions
                      , hedis
                      , lens
+                     , par-dual
                      , postgresql-simple
                      , prettyprinter
                      , raw-strings-qq


### PR DESCRIPTION
The current implementation would validate refinement types used in Servant's query parameters in a sequential manner. Say we make a request to `/checkout`:

```bash
curl --request POST \
  --url http://localhost:8080/v1/checkout/dfffa29c-6c29-11ea-bc55-0242ac130003 \
  --header 'content-type: application/json' \
  --data '{
		"name": "",
		"number": 1111144422223333,
		"expiration": 0,
		"cvv": 0
}'
```

We would get a `400` with a single error message that corresponds to the name being empty:

```
Error in $.name: The predicate (SizeGreaterThan 0) does not hold: Text cannot be empty
```

This is because we are using the default `FromJSON` instance for refinement types, defined as follows:

```haskell
-- Source: Refined.Orphan.Aeson
instance (FromJSON a, Predicate p a) => FromJSON (Refined p a) where
  parseJSON = refineFail <=< parseJSON
```

This obviously validates one parameter at a time and it short-circuits on the first failure, as any other `Monad` would do.

By introducing `par-dual`, we can validate all these refinement types at once and accumulate errors, thanks to the `Either -> Validation -> Either` relationship defined by the `ParDual` class. 

Performing the same request while using `par-dual`, we would get the following output:

```
Error in $: ["name: The predicate (SizeGreaterThan 0) does not hold: \n  Text cannot be empty","expiration: The predicate (HasDigits 4) does not hold: \n  Invalid number of digits. Expected 4","cvv: The predicate (HasDigits 3) does not hold: \n  Invalid number of digits. Expected 3"]
```

The format could be improved but now we are returning all the validation errors at once :)